### PR TITLE
chore: bump `url` in `Cargo.lock`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",


### PR DESCRIPTION
The verison we have in `Cargo.lock` is yanked.